### PR TITLE
Allow to work with non-default Wire

### DIFF
--- a/L3G.h
+++ b/L3G.h
@@ -2,6 +2,7 @@
 #define L3G_h
 
 #include <Arduino.h> // for byte data type
+#include <Wire.h> // for byte data type
 
 class L3G
 {
@@ -74,7 +75,7 @@ class L3G
 
     L3G(void);
 
-    bool init(deviceType device = device_auto, sa0State sa0 = sa0_auto);
+    bool init(TwoWire *wire = &Wire, deviceType device = device_auto, sa0State sa0 = sa0_auto);
     deviceType getDeviceType(void) { return _device; }
 
     void enableDefault(void);
@@ -98,6 +99,7 @@ class L3G
       byte address;
 
       unsigned int io_timeout;
+      TwoWire *wire;
       bool did_timeout;
 
       int testReg(byte address, regAddr reg);

--- a/README.md
+++ b/README.md
@@ -135,8 +135,8 @@ library archive or repository.
   [`Wire.endTransmission()` documentation](https://arduino.cc/en/Reference/WireEndTransmission)
   for return values.
 - `L3G(void)` <br> Constructor.
-- `bool init(byte device, byte sa0)` <br> Initializes the library with
-  the device being used (`device_4200D`, `device_D20`, `device_D20H`,
+- `bool init(TwoWire theWire, byte device, byte sa0)` <br> Initializes the library with
+  the Wire, the device being used (`device_4200D`, `device_D20`, `device_D20H`,
   or `device_auto`) and the state of the SA0 pin (`sa0_low`,
   `sa0_high`, or `sa0_auto`), which determines the least significant
   bit of the I²C slave address. Constants for these arguments are


### PR DESCRIPTION
Dear maintainer,

I'm using your library with esp32 and I need to use specific SDA, SCL pins and maybe I need more than one bus, so I had to fix your library a bit to allow to pass TwoWire instance in the init method with default value = &Wire. 

